### PR TITLE
Add null check to Engine.setupChat()

### DIFF
--- a/src/main/java/com/Alvaeron/Engine.java
+++ b/src/main/java/com/Alvaeron/Engine.java
@@ -111,6 +111,7 @@ public class Engine extends JavaPlugin {
 
 	private boolean setupChat() {
 		RegisteredServiceProvider<Chat> rsp = getServer().getServicesManager().getRegistration(Chat.class);
+		if (rsp == null) return false;
 		chat = rsp.getProvider();
 		return chat != null;
 	}


### PR DESCRIPTION
The getRegistration method is allowed to return null, which causes a NullPointerException when you try to invoke its getProvider method. A simple null check fixes that issue.
A friend of mine got such a NullPointerException when using your plug-in, even though I couldn't reproduce this situation myself. I rebuild your plug-in with this change, and that new build worked very well according to him.